### PR TITLE
Upgrade development dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,11 +39,11 @@ pyright = "1.1.347"
 ruff = "^0.1.14"
 
 [tool.poetry.group.tests.dependencies]
-coverage = { extras = ["toml"], version = "^7.3.2" }
-pytest = "^7.4.2"
+coverage = { extras = ["toml"], version = "^7.4.1" }
+pytest = "^7.4.4"
 pytest-cov = "^4.1.0"
 pytest-httpx = "0.22.0"
-pytest-watcher = "^0.3.4"
+pytest-watcher = "^0.3.5"
 
 [tool.coverage.paths]
 source = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ mypy = "^1.8.0"
 pyright = "1.1.347"
 
 [tool.poetry.group.ruff.dependencies]
-ruff = "^0.1.4"
+ruff = "^0.1.14"
 
 [tool.poetry.group.tests.dependencies]
 coverage = { extras = ["toml"], version = "^7.3.2" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ sphinx-autodoc-typehints = ">= 1.12"
 mypy = "^1.8.0"
 
 [tool.poetry.group.pyright.dependencies]
-pyright = "^1.1.336"
+pyright = "1.1.347"
 
 [tool.poetry.group.ruff.dependencies]
 ruff = "^0.1.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ sphinx-rtd-theme = ">= 1.2"
 sphinx-autodoc-typehints = ">= 1.12"
 
 [tool.poetry.group.mypy.dependencies]
-mypy = "^1.7.0"
+mypy = "^1.8.0"
 
 [tool.poetry.group.pyright.dependencies]
 pyright = "^1.1.336"


### PR DESCRIPTION
- Bump mypy from 1.7.0 to 1.8.0
- Bump pyright from 1.1.336 to 1.1.347 (pinned)
- Bump ruff from 0.1.4 to 0.1.14
- Bump test dependencies
