### PR TITLE
Test remaining bits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ branch = true
 source = ["brreg"]
 
 [tool.coverage.report]
-fail_under = 85
+fail_under = 100
 show_missing = true
 
 [tool.pytest.ini_options]

--- a/src/brreg/enhetsregisteret/_client.py
+++ b/src/brreg/enhetsregisteret/_client.py
@@ -1,12 +1,12 @@
-from __future__ import annotations
-
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Generator, List, Optional
+from types import TracebackType
+from typing import Any, Generator, List, Optional, Type
 
 import httpx
 
 from brreg import BrregError, BrregRestError
 from brreg.enhetsregisteret._pagination import Cursor, EnhetPage, UnderenhetPage
+from brreg.enhetsregisteret._queries import EnhetQuery, UnderenhetQuery
 from brreg.enhetsregisteret._responses import (
     Enhet,
     RolleGruppe,
@@ -17,11 +17,6 @@ from brreg.enhetsregisteret._types import (
     Organisasjonsnummer,
     OrganisasjonsnummerValidator,
 )
-
-if TYPE_CHECKING:
-    from types import TracebackType
-
-    from brreg.enhetsregisteret._queries import EnhetQuery, UnderenhetQuery
 
 
 class Client:
@@ -46,14 +41,14 @@ class Client:
     def __init__(self) -> None:
         self.open()
 
-    def __enter__(self) -> Client:
+    def __enter__(self) -> "Client":
         return self
 
     def __exit__(
         self,
-        exc_type: type[BaseException] | None = None,
-        exc_value: BaseException | None = None,
-        traceback: TracebackType | None = None,
+        exc_type: Optional[Type[BaseException]] = None,
+        exc_value: Optional[BaseException] = None,
+        traceback: Optional[TracebackType] = None,
     ) -> None:
         self.close()
 
@@ -188,7 +183,7 @@ def error_handler() -> Generator[None, Any, None]:
     try:
         yield
     except httpx.HTTPError as exc:
-        response: httpx.Response | None = getattr(exc, "response", None)
+        response: Optional[httpx.Response] = getattr(exc, "response", None)
         raise BrregRestError(
             str(exc),
             method=(exc.request.method if exc.request else None),

--- a/src/brreg/enhetsregisteret/_pagination.py
+++ b/src/brreg/enhetsregisteret/_pagination.py
@@ -1,11 +1,10 @@
-from __future__ import annotations
-
 from typing import (
     Callable,
     Dict,
     Generic,
     Iterator,
     List,
+    Optional,
     TypeVar,
 )
 
@@ -58,7 +57,7 @@ class Page(BaseModel, Generic[T]):
 class Cursor(Generic[T, Q]):
     """Cursor for iterating over multiple pages of items."""
 
-    _operation: Callable[[Q], Cursor[T, Q]]
+    _operation: Callable[[Q], "Cursor[T, Q]"]
     _query: Q
     _pages: Dict[int, Page[T]]
     _current_page_number: int
@@ -68,7 +67,7 @@ class Cursor(Generic[T, Q]):
 
     def __init__(
         self,
-        operation: Callable[[Q], Cursor[T, Q]],
+        operation: Callable[[Q], "Cursor[T, Q]"],
         query: Q,
         page: Page[T],
     ) -> None:
@@ -78,7 +77,7 @@ class Cursor(Generic[T, Q]):
         # Expose the empty first page, even if it says the totalt number of pages is 0.
         self.page_numbers = range(max(1, page.total_pages))
 
-    def get_page(self, page_number: int) -> Page[T] | None:
+    def get_page(self, page_number: int) -> Optional[Page[T]]:
         """Get a page by its 0-indexed page number."""
         if page_number not in self.page_numbers:
             return None

--- a/tests/enhetsregisteret/test_client.py
+++ b/tests/enhetsregisteret/test_client.py
@@ -1,0 +1,14 @@
+from brreg import enhetsregisteret
+
+
+def test_manual_open_close() -> None:
+    client = enhetsregisteret.Client()
+    assert not client._client.is_closed  # noqa: SLF001
+    client.close()
+    assert client._client.is_closed  # noqa: SLF001
+
+
+def test_context_manager() -> None:
+    with enhetsregisteret.Client() as client:
+        assert not client._client.is_closed  # noqa: SLF001
+    assert client._client.is_closed  # noqa: SLF001

--- a/tests/enhetsregisteret/test_get_enhet.py
+++ b/tests/enhetsregisteret/test_get_enhet.py
@@ -91,11 +91,12 @@ def test_get_enhet_when_deleted(httpx_mock: HTTPXMock) -> None:
     assert org.slettedato == date(2017, 10, 20)
 
 
-def test_get_enhet_when_gone(httpx_mock: HTTPXMock) -> None:
+@pytest.mark.parametrize("status_code", [404, 410])
+def test_get_enhet_when_4xx(httpx_mock: HTTPXMock, status_code: int) -> None:
     httpx_mock.add_response(  # pyright: ignore[reportUnknownMemberType]
         method="GET",
         url="https://data.brreg.no/enhetsregisteret/api/enheter/818511752",
-        status_code=410,
+        status_code=status_code,
         headers={"content-type": "application/json"},
     )
 
@@ -104,20 +105,7 @@ def test_get_enhet_when_gone(httpx_mock: HTTPXMock) -> None:
     assert org is None
 
 
-def test_get_enhet_when_not_found(httpx_mock: HTTPXMock) -> None:
-    httpx_mock.add_response(  # pyright: ignore[reportUnknownMemberType]
-        method="GET",
-        url="https://data.brreg.no/enhetsregisteret/api/enheter/818511752",
-        status_code=404,
-        headers={"content-type": "application/json"},
-    )
-
-    org = enhetsregisteret.Client().get_enhet("818511752")
-
-    assert org is None
-
-
-def test_get_enhet_when_http_error(httpx_mock: HTTPXMock) -> None:
+def test_get_enhet_when_bad_request(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(  # pyright: ignore[reportUnknownMemberType]
         method="GET",
         url="https://data.brreg.no/enhetsregisteret/api/enheter/818511752",
@@ -139,7 +127,7 @@ def test_get_enhet_when_http_error(httpx_mock: HTTPXMock) -> None:
     assert exc_info.value.status_code == 400
 
 
-def test_get_organization_by_number_when_http_timeout(httpx_mock: HTTPXMock) -> None:
+def test_get_enhet_when_http_timeout(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_exception(  # pyright: ignore[reportUnknownMemberType]
         httpx.ConnectTimeout("Connection refused"),
     )

--- a/tests/enhetsregisteret/test_get_roller.py
+++ b/tests/enhetsregisteret/test_get_roller.py
@@ -1,6 +1,7 @@
 from datetime import date
 from pathlib import Path
 
+import pytest
 from pytest_httpx import HTTPXMock
 
 from brreg import enhetsregisteret
@@ -102,3 +103,17 @@ def test_get_roller_with_enhet(httpx_mock: HTTPXMock) -> None:
     assert rolle.ansvarsandel == "50%"
     assert rolle.fratraadt is False
     assert rolle.rekkefolge == 1
+
+
+@pytest.mark.parametrize("status_code", [404, 410])
+def test_get_underenhet_when_4xx(httpx_mock: HTTPXMock, status_code: int) -> None:
+    httpx_mock.add_response(  # pyright: ignore[reportUnknownMemberType]
+        method="GET",
+        url="https://data.brreg.no/enhetsregisteret/api/enheter/810004622/roller",
+        status_code=status_code,
+        headers={"content-type": "application/json"},
+    )
+
+    rollegrupper = enhetsregisteret.Client().get_roller("810004622")
+
+    assert rollegrupper == []

--- a/tests/enhetsregisteret/test_get_underenhet.py
+++ b/tests/enhetsregisteret/test_get_underenhet.py
@@ -1,6 +1,7 @@
 from datetime import date
 from pathlib import Path
 
+import pytest
 from pytest_httpx import HTTPXMock
 
 from brreg import enhetsregisteret
@@ -82,3 +83,17 @@ def test_get_underenhet_when_deleted(httpx_mock: HTTPXMock) -> None:
         utgaatt=None,
     )
     assert org.slettedato == date(2017, 10, 20)
+
+
+@pytest.mark.parametrize("status_code", [404, 410])
+def test_get_underenhet_when_4xx(httpx_mock: HTTPXMock, status_code: int) -> None:
+    httpx_mock.add_response(  # pyright: ignore[reportUnknownMemberType]
+        method="GET",
+        url="https://data.brreg.no/enhetsregisteret/api/underenheter/987123456",
+        status_code=status_code,
+        headers={"content-type": "application/json"},
+    )
+
+    org = enhetsregisteret.Client().get_underenhet("987123456")
+
+    assert org is None

--- a/tests/enhetsregisteret/test_search_enhet.py
+++ b/tests/enhetsregisteret/test_search_enhet.py
@@ -166,6 +166,12 @@ def test_search_enhet_with_pagination(httpx_mock: HTTPXMock) -> None:
     ]
     assert len(httpx_mock.get_requests()) == 2  # pyright: ignore[reportUnknownMemberType]
 
+    # Fetching a page that does not exist should return None, and not trigger
+    # any HTTP requests:
+    page2 = cursor.get_page(2)
+    assert page2 is None
+    assert len(httpx_mock.get_requests()) == 2  # pyright: ignore[reportUnknownMemberType]
+
     # Iterating over the pages returns all pages:
     assert list(cursor.pages) == [page0, page1]
 


### PR DESCRIPTION
This PR takes the project's line test coverage to 100%. The test suite is
configured to fails if this is not maintained with future changes.

- Test `Cursor.get_page()` with a non-existant page
- Test various ways of opening and closing the client
- Test 404 and 410 responses
- Test handling of non-HTTP errors
- Ensure all type annotations works on Python 3.8
- Require the current full test coverage to be maintained
