### PR TITLE
Remove `Enhet.nedleggelsesdato` field

### DIFF
--- a/src/brreg/enhetsregisteret/_responses.py
+++ b/src/brreg/enhetsregisteret/_responses.py
@@ -185,9 +185,6 @@ class Enhet(BaseModel):
     #: Enhetens aktivitet
     aktivitet: list[str] = Field(default_factory=list)
 
-    #: Nedleggelsesdato for underenheten
-    nedleggelsesdato: DateOrNone = None
-
     #: Dato under-/enheten ble slettet
     slettedato: DateOrNone = None
 


### PR DESCRIPTION
Uncertain if it was removed from the API or if it was never part of the API and we added it to the library by accident.

The `nedleggelsesdato` field still exists on the `Underenhet` type.