### PR TITLE
Fix `EnhetQuery` search parameter serialization

### DIFF
--- a/src/brreg/enhetsregisteret/_queries.py
+++ b/src/brreg/enhetsregisteret/_queries.py
@@ -107,10 +107,16 @@ class EnhetQuery(Query):
 
     #: Hvorvidt enheten er registrert som under tvangsavvikling eller
     #: tvangsoppløsning
-    under_tvangsavvikling_eller_tvangsopplosning: bool | None = None
+    under_tvangsavvikling_eller_tvangsopplosning: bool | None = Field(
+        default=None,
+        serialization_alias="underTvangsavviklingEllerTvangsopplosning",
+    )
 
     #: Hvorvidt enheten er registrert som under avvikling
-    under_avvikling: bool | None = None
+    under_avvikling: bool | None = Field(
+        default=None,
+        serialization_alias="underAvvikling",
+    )
 
     #: Tidligste registreringsdato i Enhetsregisteret
     fra_registreringsdato_enhetsregisteret: dt.date | None = Field(
@@ -147,6 +153,7 @@ class EnhetQuery(Query):
     #: Enhetens institusjonelle sektorkode
     institusjonell_sektorkode: CommaList[Sektorkode] = Field(
         default_factory=list,
+        serialization_alias="institusjonellSektorkode",
     )
 
     #: Kommunenummer til enhetens postadresse


### PR DESCRIPTION
Three fields lacked a `serialization_alias`, so they were sent to the API with `snake_case` names that the API silently ignored.