### PR TITLE
Migrate from httpx to httpx2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries",
 ]
-dependencies = ["httpx>=0.24", "pydantic>=2"]
+dependencies = ["httpx2>=2", "pydantic>=2"]
 
 [project.urls]
 Homepage = "https://github.com/crdbrd/python-brreg"
@@ -41,10 +41,10 @@ pyright = ["basedpyright==1.39.6"]
 ruff = ["ruff==0.15.14"]
 tests = [
     "coverage>=7.6.12",
-    "pytest>=8.3.4",
+    "httpx2-pytest>=1",
     "pytest-cov>=6.0.0",
-    "pytest-httpx>=0.35.0",
     "pytest-watcher>=0.4.3",
+    "pytest>=8.3.4",
 ]
 ty = ["ty==0.0.39"]
 zizmor = ["zizmor==1.25.2"]

--- a/src/brreg/enhetsregisteret/_client.py
+++ b/src/brreg/enhetsregisteret/_client.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 from types import TracebackType
 from typing import Any
 
-import httpx
+import httpx2
 
 import brreg
 from brreg import BrregError, BrregRestError
@@ -38,7 +38,7 @@ class Client:
         client.close()
     """
 
-    _client: httpx.Client
+    _client: httpx2.Client
 
     def __init__(self) -> None:
         self.open()
@@ -59,11 +59,12 @@ class Client:
 
         This is called automatically when the client is created.
         """
-        self._client = httpx.Client(
+        self._client = httpx2.Client(
             base_url="https://data.brreg.no/enhetsregisteret/api",
             headers={
                 "user-agent": (
-                    f"python-brreg/{brreg.__version__} python-httpx/{httpx.__version__}"
+                    f"python-brreg/{brreg.__version__} "
+                    f"python-httpx2/{httpx2.__version__}"
                 ),
             },
         )
@@ -188,8 +189,8 @@ class Client:
 def error_handler() -> Generator[None, Any, None]:
     try:
         yield
-    except httpx.HTTPError as exc:
-        response: httpx.Response | None = getattr(exc, "response", None)
+    except httpx2.HTTPError as exc:
+        response: httpx2.Response | None = getattr(exc, "response", None)
         raise BrregRestError(
             str(exc),
             method=(exc.request.method if exc.request else None),

--- a/tests/enhetsregisteret/test_get_enhet.py
+++ b/tests/enhetsregisteret/test_get_enhet.py
@@ -1,9 +1,9 @@
 from datetime import date
 from pathlib import Path
 
-import httpx
+import httpx2
 import pytest
-from pytest_httpx import HTTPXMock
+from pytest_httpx2 import HTTPXMock
 
 import brreg
 from brreg import BrregError, BrregRestError, enhetsregisteret
@@ -26,7 +26,7 @@ def test_get_enhet(httpx_mock: HTTPXMock) -> None:
     assert len(requests) == 1
     assert (
         requests[0].headers["user-agent"]
-        == f"python-brreg/{brreg.__version__} python-httpx/{httpx.__version__}"
+        == f"python-brreg/{brreg.__version__} python-httpx2/{httpx2.__version__}"
     )
 
     assert org is not None
@@ -138,7 +138,7 @@ def test_get_enhet_when_bad_request(httpx_mock: HTTPXMock) -> None:
 
 def test_get_enhet_when_http_timeout(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_exception(  # pyright: ignore[reportUnknownMemberType]
-        httpx.ConnectTimeout("Connection refused"),
+        httpx2.ConnectTimeout("Connection refused"),
     )
 
     with pytest.raises(BrregRestError) as exc_info:

--- a/tests/enhetsregisteret/test_get_roller.py
+++ b/tests/enhetsregisteret/test_get_roller.py
@@ -1,9 +1,9 @@
 from datetime import date
 from pathlib import Path
 
-import httpx
+import httpx2
 import pytest
-from pytest_httpx import HTTPXMock
+from pytest_httpx2 import HTTPXMock
 
 import brreg
 from brreg import enhetsregisteret
@@ -26,7 +26,7 @@ def test_get_roller_with_person(httpx_mock: HTTPXMock) -> None:
     assert len(requests) == 1
     assert (
         requests[0].headers["user-agent"]
-        == f"python-brreg/{brreg.__version__} python-httpx/{httpx.__version__}"
+        == f"python-brreg/{brreg.__version__} python-httpx2/{httpx2.__version__}"
     )
 
     assert rollegrupper

--- a/tests/enhetsregisteret/test_get_underenhet.py
+++ b/tests/enhetsregisteret/test_get_underenhet.py
@@ -1,9 +1,9 @@
 from datetime import date
 from pathlib import Path
 
-import httpx
+import httpx2
 import pytest
-from pytest_httpx import HTTPXMock
+from pytest_httpx2 import HTTPXMock
 
 import brreg
 from brreg import enhetsregisteret
@@ -26,7 +26,7 @@ def test_get_underenhet(httpx_mock: HTTPXMock) -> None:
     assert len(requests) == 1
     assert (
         requests[0].headers["user-agent"]
-        == f"python-brreg/{brreg.__version__} python-httpx/{httpx.__version__}"
+        == f"python-brreg/{brreg.__version__} python-httpx2/{httpx2.__version__}"
     )
 
     assert org is not None

--- a/tests/enhetsregisteret/test_search_enhet.py
+++ b/tests/enhetsregisteret/test_search_enhet.py
@@ -1,8 +1,8 @@
 from datetime import date
 from pathlib import Path
 
-import httpx
-from pytest_httpx import HTTPXMock
+import httpx2
+from pytest_httpx2 import HTTPXMock
 
 import brreg
 from brreg import enhetsregisteret
@@ -59,7 +59,7 @@ def test_search_enhet(httpx_mock: HTTPXMock) -> None:
     assert len(requests) == 1
     assert (
         requests[0].headers["user-agent"]
-        == f"python-brreg/{brreg.__version__} python-httpx/{httpx.__version__}"
+        == f"python-brreg/{brreg.__version__} python-httpx2/{httpx2.__version__}"
     )
 
     page = next(cursor.pages)

--- a/tests/enhetsregisteret/test_search_underenhet.py
+++ b/tests/enhetsregisteret/test_search_underenhet.py
@@ -1,8 +1,8 @@
 from datetime import date
 from pathlib import Path
 
-import httpx
-from pytest_httpx import HTTPXMock
+import httpx2
+from pytest_httpx2 import HTTPXMock
 
 import brreg
 from brreg import enhetsregisteret
@@ -54,7 +54,7 @@ def test_search_underenhet(httpx_mock: HTTPXMock) -> None:
     assert len(requests) == 1
     assert (
         requests[0].headers["user-agent"]
-        == f"python-brreg/{brreg.__version__} python-httpx/{httpx.__version__}"
+        == f"python-brreg/{brreg.__version__} python-httpx2/{httpx2.__version__}"
     )
 
     page = next(cursor.pages)


### PR DESCRIPTION
httpx has not had a release in 18 months, while the fork httpx2 is actively maintained.